### PR TITLE
ValueSlot Optimizations

### DIFF
--- a/code/Lua/Table.cs
+++ b/code/Lua/Table.cs
@@ -120,17 +120,32 @@ namespace Miku.Lua
 			}
 		}
 
+		private bool TryGetInt( ValueSlot valueSlot, out int value )
+		{
+			if ( valueSlot.Kind == ValueKind.Number )
+			{
+				var d = valueSlot.UnsafeGetNumber();
+				var i = (int)d;
+				if ( Math.Abs( d - i ) <= double.Epsilon )
+				{
+					value = i;
+					return true;
+				}
+			}
+
+			value = default;
+			return false;
+		}
+
 		public ValueSlot Get( ValueSlot key )
 		{
 			if (Array != null)
 			{
-				if ( key.Kind == ValueKind.Number )
+				if ( TryGetInt( key, out var idx ) )
 				{
-					var i_dbl = key.CheckNumber();
-					int i = (int)i_dbl;
-					if ( i_dbl == i && i >= 1 && i <= Array.Count )
+					if ( idx >= 1 && idx <= Array.Count )
 					{
-						return ArrayGet( i );
+						return ArrayGet( idx );
 					}
 				}
 			}

--- a/code/Lua/ValueSlot.cs
+++ b/code/Lua/ValueSlot.cs
@@ -204,7 +204,8 @@ namespace Miku.Lua
 						{
 							return val.Reference == null;
 						}
-						return this.Reference.Equals( val.Reference );
+						return ReferenceEquals( Reference, val.Reference )
+							   || this.Reference.Equals( val.Reference );
 					}
 				}
 			}

--- a/code/Lua/ValueSlot.cs
+++ b/code/Lua/ValueSlot.cs
@@ -1,11 +1,9 @@
-#nullable enable
+﻿#nullable enable
 
 using System;
 
 namespace Miku.Lua
 {
-	using UserFunctionOld = Func<ValueSlot[], Executor, ValueSlot[]?>;
-
 	enum ValueKind
 	{
 		Nil,

--- a/code/Lua/ValueSlot.cs
+++ b/code/Lua/ValueSlot.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Diagnostics;
 
 namespace Miku.Lua
 {
@@ -75,6 +76,8 @@ namespace Miku.Lua
 			throw new Exception( $"{this} is not a table." );
 		}
 
+		public Table UnsafeGetTable() => (Table)Reference!;
+
 		public double CheckNumber()
 		{
 			if ( Kind == ValueKind.Number )
@@ -83,6 +86,8 @@ namespace Miku.Lua
 			}
 			throw new Exception( $"{this} is not a number." );
 		}
+
+		public double UnsafeGetNumber() => NumberValue;
 
 		public ProtoFunction CheckProtoFunction()
 		{
@@ -101,6 +106,8 @@ namespace Miku.Lua
 			}
 			throw new Exception( $"{this} is not a string." );
 		}
+
+		public string UnsafeGetString() => (string)Reference!;
 
 		public string? TryGetString()
 		{

--- a/code/Lua/ValueSlot.cs
+++ b/code/Lua/ValueSlot.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 
@@ -19,18 +19,18 @@ namespace Miku.Lua
 		UserData
 	}
 
-	struct ValueSlot
+	readonly struct ValueSlot
 	{
 		public readonly ValueKind Kind;
 		private readonly object? Reference;
 		private readonly double NumberValue;
 
 		// primitives
-		public static readonly ValueSlot NIL = new ValueSlot(ValueKind.Nil);
-		public static readonly ValueSlot TRUE = new ValueSlot(ValueKind.True);
-		public static readonly ValueSlot FALSE = new ValueSlot(ValueKind.False);
+		public static readonly ValueSlot NIL = new ValueSlot( ValueKind.Nil );
+		public static readonly ValueSlot TRUE = new ValueSlot( ValueKind.True );
+		public static readonly ValueSlot FALSE = new ValueSlot( ValueKind.False );
 
-		private ValueSlot(ValueKind kind, object? ref_obj = null, double n = 0)
+		private ValueSlot( ValueKind kind, object? ref_obj = null, double n = 0 )
 		{
 			Kind = kind;
 			Reference = ref_obj;
@@ -70,7 +70,8 @@ namespace Miku.Lua
 
 		public Table CheckTable()
 		{
-			if ( Kind == ValueKind.Table ) {
+			if ( Kind == ValueKind.Table )
+			{
 				return (Table)Reference!;
 			}
 			throw new Exception( $"{this} is not a table." );
@@ -78,7 +79,8 @@ namespace Miku.Lua
 
 		public double CheckNumber()
 		{
-			if ( Kind == ValueKind.Number ) {
+			if ( Kind == ValueKind.Number )
+			{
 				return NumberValue;
 			}
 			throw new Exception( $"{this} is not a number." );
@@ -86,7 +88,8 @@ namespace Miku.Lua
 
 		public ProtoFunction CheckProtoFunction()
 		{
-			if (Kind == ValueKind.ProtoFunction) {
+			if ( Kind == ValueKind.ProtoFunction )
+			{
 				return (ProtoFunction)Reference!;
 			}
 			throw new Exception( $"{this} is not a function prototype." );
@@ -94,7 +97,7 @@ namespace Miku.Lua
 
 		public string CheckString()
 		{
-			if (Kind == ValueKind.String )
+			if ( Kind == ValueKind.String )
 			{
 				return (string)Reference!;
 			}
@@ -121,7 +124,8 @@ namespace Miku.Lua
 
 		public Function CheckFunction()
 		{
-			if ( Kind == ValueKind.Function ) {
+			if ( Kind == ValueKind.Function )
+			{
 				return (Function)Reference!;
 			}
 			throw new Exception( $"{this} is not a function." );
@@ -138,7 +142,7 @@ namespace Miku.Lua
 
 		public ValueSlot CloneCheck()
 		{
-			switch (this.Kind)
+			switch ( this.Kind )
 			{
 				case ValueKind.Nil:
 				case ValueKind.True:
@@ -153,11 +157,11 @@ namespace Miku.Lua
 
 		public override string ToString()
 		{
-			if (Kind == ValueKind.String)
+			if ( Kind == ValueKind.String )
 			{
 				return Reference!.ToString()!;
 			}
-			if (Kind == ValueKind.Number)
+			if ( Kind == ValueKind.Number )
 			{
 				return NumberValue.ToString();
 			}
@@ -167,11 +171,11 @@ namespace Miku.Lua
 		public override int GetHashCode()
 		{
 			int hash = Kind.GetHashCode();
-			if (Kind == ValueKind.Number)
+			if ( Kind == ValueKind.Number )
 			{
 				hash ^= NumberValue.GetHashCode();
 			}
-			if (Reference != null)
+			if ( Reference != null )
 			{
 				hash ^= Reference.GetHashCode();
 			}
@@ -180,21 +184,22 @@ namespace Miku.Lua
 
 		public override bool Equals( object? obj )
 		{
-			if (obj is ValueSlot)
+			if ( obj is ValueSlot )
 			{
 				var val = (ValueSlot)obj;
-				if (this.Kind == val.Kind)
+				if ( this.Kind == val.Kind )
 				{
-					if (this.Kind == ValueKind.Number)
+					if ( this.Kind == ValueKind.Number )
 					{
 						return this.NumberValue == val.NumberValue;
-					} else
+					}
+					else
 					{
-						if (this.Reference == null)
+						if ( this.Reference == null )
 						{
 							return val.Reference == null;
 						}
-						return this.Reference.Equals( val.Reference ); 
+						return this.Reference.Equals( val.Reference );
 					}
 				}
 			}


### PR DESCRIPTION
Optimizes a few things in `ValueSlot`:
- Makes it `readonly`.
  This tells the compiler that the `struct` cannot be modified so it won't do any safety copies and will pass it by reference or directly instead.
- Removes an unused "delegate" (in quotes because it was a local alias).
- Adds a method to get the `double`, `Table` or `string` value of a `ValueSlot` without `Kind` checks.
  This is a micro-optimization to remove redundant checks in places where we've already checked `Kind`.
- Improve integer indexing.
  This uses a better method for checking if a `double` is integral (as floating point errors can happen).
  I don't know if it is faster than the previous method but it should be more correct at least.